### PR TITLE
KF-198: Install community operator using one yaml file

### DIFF
--- a/deploy/new_operator.yaml
+++ b/deploy/new_operator.yaml
@@ -1,0 +1,110 @@
+# Steps from https://github.com/kubeflow/kfctl/blob/master/operator.md#deployment-instructions
+# used to deploy operator was merged into the yaml file. 
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kubeflow-operator
+  labels:
+    name: kubeflow-operator
+---
+# ./crds/kfdef.apps.kubeflow.org_kfdefs_crd.yaml
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kfdefs.kfdef.apps.kubeflow.org
+spec:
+  group: kfdef.apps.kubeflow.org
+  names:
+    kind: KfDef
+    listKind: KfDefList
+    plural: kfdefs
+    singular: kfdef
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: KfDef is the Schema for the kfdefs API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: KfDefSpec defines the desired state of KfDef
+          type: object
+        status:
+          description: KfDefStatus defines the observed state of KfDef
+          type: object
+      type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+---
+# ./service_account.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kubeflow-operator
+  namespace: kubeflow-operator
+---
+# kubectl create clusterrolebinding kubeflow-operator --clusterrole cluster-admin \
+# --serviceaccount=${OPERATOR_NAMESPACE}:kubeflow-operator    
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubeflow-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: kubeflow-operator
+  namespace: kubeflow-operator
+---
+# operator.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kubeflow-operator
+  namespace: kubeflow-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: kubeflow-operator
+  template:
+    metadata:
+      labels:
+        name: kubeflow-operator
+    spec:
+      serviceAccountName: kubeflow-operator
+      containers:
+        - name: kubeflow-operator
+          # Replace this with the built image name
+          image: aipipeline/kubeflow-operator:v1.0.0
+          command:
+          - kfctl
+          imagePullPolicy: Always
+          env:
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: OPERATOR_NAME
+              value: "kubeflow-operator"


### PR DESCRIPTION
1. Added new_operator.yaml which allows to deploy operator resources
   into 'kubeflow-operator' namespace in one step.